### PR TITLE
fix: pushScope when in textarea

### DIFF
--- a/src/ui/translator-components/ViewPage.svelte
+++ b/src/ui/translator-components/ViewPage.svelte
@@ -3,7 +3,7 @@
 
 	import type {Writable} from "svelte/store";
 	import {horizontalSlide} from "../animations";
-	import {Button, Dropdown, TextArea} from "../components";
+	import {Dropdown, TextArea} from "../components";
 	import {NavHeader, View} from "../obsidian-components";
 
 	import type {PluginData, TranslatorPluginSettings} from "../../types";
@@ -24,7 +24,7 @@
 	let language_to_observer: any;
 	let language_from_observer: any;
 
-	async function translate() {
+	export async function translate() {
 		if (!$settings.service_settings[$settings.translation_service].validated) {
 			if (!plugin.settings_open)
 				plugin.message_queue("Translation service is not validated");

--- a/src/view.ts
+++ b/src/view.ts
@@ -1,5 +1,4 @@
 import {ItemView, Scope, WorkspaceLeaf} from "obsidian";
-import type {KeymapEventHandler} from "obsidian";
 import type TranslatorPlugin from "./main";
 
 import type {SvelteComponent} from "svelte";
@@ -10,14 +9,26 @@ import {TRANSLATOR_VIEW_ID} from "./constants";
 
 export class TranslatorView extends ItemView {
 	plugin: TranslatorPlugin;
-	scope: Scope;
 	private view: SvelteComponent;
-	shortcut: KeymapEventHandler;
+	scope: Scope;
+	in: Element;
+	out: Element;
 
 	constructor(leaf: WorkspaceLeaf, plugin: TranslatorPlugin) {
 		super(leaf);
 		this.plugin = plugin;
-		this.scope = new Scope(this.app.scope);
+		this.scope = new Scope(app.scope)
+		this.scope.register(['Mod'], 'Enter', (e) => {
+			this.view.translate();
+			return false;
+		});
+	}
+
+	push() {
+		app.keymap.pushScope(this.scope);
+	}
+	pop() {
+		app.keymap.popScope(this.scope);
 	}
 
 	getViewType() {
@@ -46,12 +57,16 @@ export class TranslatorView extends ItemView {
 				data: this.plugin.plugin_data,
 			}
 		});
-		this.shortcut = this.scope.register(['Mod'], 'Enter', () => {});
+		this.in = containerEl.getElementsByClassName('translator-textarea')[0]
+		this.in.addEventListener('DOMActivate', () => this.push())
+		this.out = containerEl.getElementsByClassName('translator-textarea')[0]
+		this.out.addEventListener('mouseout', () => this.pop())
 	}
 
 	async onClose() {
 		this.view.$destroy();
-		this.scope.unregister(this.shortcut);
+		this.pop()
+		this.containerEl.detach()
 	}
 
 	onResize() {


### PR DESCRIPTION
When the textarea is active, mod-enter is pushed, when the mouse goes out of it, it gets removed.

My solution isn't pretty, but it makes sure that when another hotkey is assigned to mod-enter, that the textarea takes over that hotkey while it is focused/the mouse is in it.